### PR TITLE
Build e deploy funzionanti

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,5 @@
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/gloddo/react-worksapp/issues"
-  },
-  "homepage": "https://github.com/gloddo/react-worksapp#readme"
+  }
 }

--- a/public/index.html
+++ b/public/index.html
@@ -1,13 +1,3 @@
-<!-- Firebase App is always required and must be first -->
-<script src="https://www.gstatic.com/firebasejs/5.9.2/firebase-app.js"></script>
-
-<!-- Add additional services that you want to use -->
-<script src="https://www.gstatic.com/firebasejs/5.9.2/firebase-auth.js"></script>
-<script src="https://www.gstatic.com/firebasejs/5.9.2/firebase-database.js"></script>
-<script src="https://www.gstatic.com/firebasejs/5.9.2/firebase-firestore.js"></script>
-<script src="https://www.gstatic.com/firebasejs/5.9.2/firebase-messaging.js"></script>
-<script src="https://www.gstatic.com/firebasejs/5.9.2/firebase-functions.js"></script
-><!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />


### PR DESCRIPTION
Il problema sulla build era derivato dal fatto che su package.json era presente l'opzione `homepage`

REF https://facebook.github.io/create-react-app/docs/advanced-configuration

quella proprietà alterava `%PUBLIC_URL%` che è presente in `index.html`  
In parole povere il risultato era che tutti gli URL alle risorse javascript erano rotte nella build, venivano prefissate da `/gloddo/react-worksapp`